### PR TITLE
Validate webhook event - fixes TypeError

### DIFF
--- a/src/ProcessSendgridWebhookJob.php
+++ b/src/ProcessSendgridWebhookJob.php
@@ -35,7 +35,7 @@ class ProcessSendgridWebhookJob extends ProcessWebhookJob
     {
         if (!$send = $this->getSend($rawEvent)) {
             return;
-        };
+        }
 
         $sendgridEvent = SendgridEventFactory::createForPayload($rawEvent);
 
@@ -45,6 +45,10 @@ class ProcessSendgridWebhookJob extends ProcessWebhookJob
     protected function getSend(array $rawEvent): ?Send
     {
         $sendUuid = Arr::get($rawEvent, 'send_uuid');
+        
+        if (! $sendUuid) {
+            return null;
+        }
 
         return Send::findByUuid($sendUuid);
     }


### PR DESCRIPTION
Fixes TypeError: Argument 1 passed to Spatie\Mailcoach\Models\Send::findByUuid() must be of the type string, null given.

This happens for events triggered for non-mailcoach campaigns.